### PR TITLE
Add 'Classic Fantasy Roster' Template (6th Edition & TOW Compatibility)

### DIFF
--- a/classic_fantasy_roster.html
+++ b/classic_fantasy_roster.html
@@ -1,0 +1,493 @@
+<template>      
+<set name="ruleProfiles" value="special rule,rule,rules,command"/>
+
+<table class="master-print-table">
+  
+  <tfoot>
+    <tr>
+      <td>
+        <div class="footer-stamp">COPYRIGHT GAMES WORKSHOP LTD 2000. PERMISSION IS GRANTED TO PHOTOCOPY THIS PAGE FOR PERSONAL USE ONLY. TEMPLATE ARCHITECTED BY KARAK NORN</div>
+      </td>
+    </tr>
+  </tfoot>
+
+  <tbody>
+    <tr>
+      <td>
+
+        <div class="roster-state-wrapper">
+          
+          <div class="scribe-controls no-print">
+            <input type="checkbox" id="hide-rules-toggle" />
+            <label for="hide-rules-toggle">
+              <strong>HIDE RULES GLOSSARY</strong> 
+              <br/>
+              <span class="control-subtext">(Check this box to instantly remove the Rules &amp; Profiles Glossary from the bottom of your Battle Forces before printing).</span>
+            </label>
+          </div>
+
+          <forces>
+            
+            <div class="force-title-banner">
+              BATTLE FORCE: 
+              <if field="customName">{{customName}} ({{catalogueName}})</if>
+              <if field="customName" type="not">{{catalogueName}}</if>
+            </div>
+
+            <div class="roster-page force-container">
+              
+              <div class="document-header">
+                <div class="header-row">
+                  <div class="header-field"><span class="label">PLAYER:</span><span class="line"></span></div>
+                  <div class="header-field"><span class="label">ARMY NAME:</span><span class="line force-name-text"><if field="customName">{{customName}}</if><if field="customName" type="not">{{name}}</if></span></div>
+                </div>
+                <div class="header-row">
+                  
+                  <div class="header-field"><span class="label">GENERAL:</span><span class="line force-name-text">
+                    <units>
+                      <set name="isGen" value="false"/>
+                      <entries recursive="true">
+                        <if field="name" type="match" value="General" flags="i"><set name="isGen" value="true"/></if>
+                        <categories><if field="name" type="match" value="General" flags="i"><set name="isGen" value="true"/></if></categories>
+                      </entries>
+                      <if field="isGen" type="equals" value="true">
+                        <if field="customName">{{customName}} (</if>{{name}}<if field="customName">)</if>
+                      </if>
+                    </units>
+                  </span></div>
+                  
+                  <div class="header-field"><span class="label">TOTAL PTS:</span><span class="line force-name-text">
+                    <costs><if field="name" type="match" value="pts" flags="i">{{value}}</if></costs>
+                  </span></div>
+                  
+                </div>
+              </div>
+
+              <categories skip-empty="true">
+                <if field="name" type="match" value="^(Lord|Lords|Heroes|Core|Special|Rare|Mercenaries|Regiments? of Renown|Characters|Special Characters|Named Characters)$" flags="i">
+                  
+                  <div class="category-block">
+                    <h3 class="category-title">{{name}}</h3>
+                    
+                    <units dedupe="true">
+                      <div class="unit-card">
+                        <table class="unit-table">
+                          
+                          <tr class="unit-header-row">
+                            <th colspan="2" class="unit-header-name">
+                              UNIT: 
+                              <if field="customName">{{customName}} ({{name}})</if>
+                              <if field="customName" type="not">{{name}}</if>
+                            </th>
+                            
+                            <th class="unit-header-size">SIZE: <span class="calc-size"><entries><if field="type" type="equals" value="model">{{number}}{{amount}}</if></entries></span><span class="fallback-size">{{number}}{{amount}}</span></th>
+
+                            <th class="unit-header-pts">PTS: 
+                              <costs><if field="name" type="match" value="pts" flags="i">{{value}}</if></costs>
+                            </th>
+                            
+                            <th class="unit-header-upgrades">UPGRADES / SELECTIONS</th>
+                            <th class="unit-header-rules">RULES</th>
+                          </tr>
+                          
+                          <tr class="unit-data-row">
+                            
+                            <td colspan="4" class="profile-cell">
+                              <profiles grouped="true" amount="false" exclude="{{ruleProfiles}}">
+                                <table class="profile-inner-table">
+                                  <items max="1">
+                                    <tr>
+                                      <th class="profile-type">{{typeName}}</th>
+                                      <characteristics><if field="length" type="not-equals" value="1"><th class="stat-heading">{{name}}</th></if></characteristics>
+                                    </tr>
+                                  </items>
+                                  <items>
+                                    <tr class="stat-row">
+                                      <characteristics>
+                                        <if field="length" type="equals" value="1">
+                                          <td class="name single-data" colspan="15">
+                                            <span class="profile-name">{{item.name}}</span><span class="data" type="markdown">{{value}}</span>
+                                          </td>
+                                        </if>
+                                      </characteristics>
+                                      <else>
+                                        <td class="name">{{item.name}}</td>
+                                        <characteristics><td class="data" type="markdown">{{value}}</td></characteristics>
+                                      </else>
+                                    </tr>
+                                  </items>
+                                </table>
+                              </profiles>
+                            </td>
+                            
+                            <td class="upgrades-cell">
+                              
+                              <costs>
+                                <if field="name" type="not-match" value="pts" flags="i">
+                                  <div class="list-item"><strong>{{name}}:</strong> {{value}}</div>
+                                </if>
+                              </costs>
+
+                              <set name="parentUnitName" value="{{name}}"/>
+                              <dedupe>
+                                <entries>
+                                  <if field="type" type="equals" value="upgrade">
+                                    <if field="name" type="not-equals" value="{{parentUnitName}}">
+                                      <div class="list-item">
+                                        <if field="number" type="greater" value="1">{{number}}x </if>
+                                        <if field="amount" type="greater" value="1">{{amount}}x </if>
+                                        {{name}}
+                                      </div>
+                                    </if>
+                                  </if>
+                                </entries>
+
+                                <entries>
+                                  <if field="type" type="equals" value="model">
+                                    <entries>
+                                      <if field="type" type="equals" value="upgrade">
+                                        <if field="name" type="not-equals" value="{{parentUnitName}}">
+                                          <div class="list-item">
+                                            <if field="number" type="greater" value="1">{{number}}x </if>
+                                            <if field="amount" type="greater" value="1">{{amount}}x </if>
+                                            {{name}}
+                                          </div>
+                                        </if>
+                                      </if>
+                                    </entries>
+                                  </if>
+                                </entries>
+                              </dedupe>
+                            </td>
+                            
+                            <td class="rules-cell">
+                              <dedupe>
+                                <rules>
+                                  <div class="list-item">{{name}}</div>
+                                </rules>
+                                <profiles include="{{ruleProfiles}}">
+                                  <div class="list-item">{{name}}</div>
+                                </profiles>
+                              </dedupe>
+                            </td>
+                          </tr>
+                          
+                        </table>
+                      </div>
+                    </units>
+                  </div>
+                  
+                </if>
+              </categories>
+
+              <div class="global-rules-section">
+                <h2 class="rules-summary-title">RULES AND ITEMS GLOSSARY</h2>
+                
+                <rules sort="true">
+                  <div class="global-rule-item">
+                    <span class="rule-name">{{name}}:</span>
+                    <span class="rule-desc" type="markdown">{{description}}</span>
+                  </div>
+                </rules>
+
+                <profiles include="{{ruleProfiles}}" sort="true">
+                  <div class="global-rule-item">
+                    <span class="rule-name">{{name}}:</span>
+                    <characteristics>
+                      <span class="rule-desc" type="markdown">{{value}}</span>
+                    </characteristics>
+                  </div>
+                </profiles>
+              </div>
+
+            </div> </forces>
+
+        </div> </td>
+    </tr>
+  </tbody>
+</table> 
+
+</template>
+
+<style>
+/* Pure Black and White Printable PDF Clone */
+@page {
+  size: auto;
+  margin: 12mm; 
+}
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background-color: #ffffff; 
+  color: #000000; 
+  font-family: Arial, Helvetica, sans-serif; 
+  font-size: 11px; 
+  line-height: 1.2;
+}
+
+* {
+  box-sizing: border-box;
+  print-color-adjust: exact !important;
+  -webkit-print-color-adjust: exact !important;
+}
+
+/* INTERACTIVE TOGGLE LOGIC */
+.scribe-controls {
+  background-color: #f5f5f5;
+  border: 2px dashed #000000;
+  margin: 20px auto;
+  padding: 15px;
+  max-width: 1000px;
+  text-align: center;
+}
+
+.control-subtext {
+  font-size: 11px;
+  font-style: italic;
+  color: #555;
+}
+
+.roster-state-wrapper:has(#hide-rules-toggle:checked) .global-rules-section {
+  display: none !important;
+}
+
+@media print {
+  .no-print { display: none !important; }
+}
+
+/* MASTER PRINT TABLE */
+.master-print-table {
+  width: 100%;
+  border-collapse: collapse;
+  border: none;
+}
+
+.master-print-table td {
+  padding: 0;
+  border: none;
+}
+
+tfoot {
+  display: table-footer-group; 
+}
+
+.footer-stamp {
+  text-align: center;
+  border-top: 1px solid #000000;
+  padding-top: 5px;
+  margin-top: 20px;
+  color: #000000;
+  font-size: 9px;
+  text-transform: uppercase;
+}
+
+/* EMPTY CATEGORY & SIZE FIXES */
+.category-block { display: none; }
+.category-block:has(.unit-card) { display: block; }
+.calc-size:not(:empty) + .fallback-size { display: none; }
+
+/* ROSTER LAYOUT */
+.force-title-banner {
+  background-color: #000000;
+  color: #ffffff;
+  text-align: center;
+  font-size: 16px;
+  font-weight: bold;
+  padding: 8px;
+  margin-top: 30px;
+  margin-bottom: 20px;
+  border: 2px solid #000000;
+  text-transform: uppercase;
+  max-width: 1000px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.force-container {
+  margin-bottom: 60px;
+  padding-bottom: 40px;
+  border-bottom: 8px solid #000000;
+  page-break-after: always;
+}
+
+.roster-page {
+  width: 100%;
+  max-width: 1000px;
+  margin: 0 auto;
+}
+
+.document-header {
+  margin-top: 20px;
+  margin-bottom: 25px;
+  width: 100%;
+}
+
+.header-row {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+
+.header-field {
+  display: flex;
+  flex: 1;
+  align-items: flex-end;
+  margin-right: 20px;
+}
+
+.header-field .label {
+  font-weight: bold;
+  font-size: 12px;
+  margin-right: 5px;
+  white-space: nowrap;
+}
+
+.header-field .line {
+  flex-grow: 1;
+  border-bottom: 1px solid #000000;
+  height: 1em;
+  padding-left: 5px;
+  font-style: italic;
+  font-size: 13px;
+}
+
+.category-title {
+  font-size: 14px;
+  font-weight: bold;
+  text-transform: uppercase;
+  background-color: #000000;
+  color: #ffffff;
+  padding: 4px 8px;
+  margin-bottom: 12px;
+  border: 1px solid #000000;
+  page-break-after: avoid;
+}
+
+.unit-card {
+  break-inside: avoid;
+  page-break-inside: avoid;
+  margin-bottom: 24px;
+  width: 100%;
+}
+
+.unit-table {
+  border-collapse: collapse;
+  width: 100%;
+  table-layout: fixed; 
+  border: 2px solid #000000; 
+  background-color: #ffffff;
+}
+
+.unit-header-row th {
+  background-color: #ffffff;
+  color: #000000;
+  font-size: 11px;
+  font-weight: bold;
+  text-transform: uppercase;
+  border: 1px solid #000000;
+  padding: 6px 8px;
+  text-align: left;
+}
+
+.unit-header-name { width: 35%; }
+.unit-header-size { width: 10%; text-align: center; }
+.unit-header-pts { width: 10%; text-align: center; }
+.unit-header-upgrades { width: 22.5%; }
+.unit-header-rules { width: 22.5%; }
+
+.unit-data-row td {
+  vertical-align: top;
+  border: 1px solid #000000;
+  padding: 0; 
+}
+
+.upgrades-cell, .rules-cell {
+  padding: 6px; 
+  font-size: 10px;
+}
+
+.list-item {
+  margin-bottom: 3px;
+  padding-left: 8px;
+  text-indent: -8px;
+}
+
+.list-item::before {
+  content: "- ";
+}
+
+.profile-inner-table {
+  border-collapse: collapse;
+  width: 100%;
+  border: none; 
+}
+
+.profile-inner-table th, .profile-inner-table td {
+  border: 1px solid #000000;
+  padding: 3px 5px; 
+  text-align: center;
+  word-wrap: break-word; 
+}
+
+.profile-inner-table th {
+  font-weight: bold;
+  text-transform: uppercase;
+  font-size: 10px;
+  background-color: #e6e6e6 !important; 
+  border-top: 1px solid #000000; 
+}
+
+.profile-inner-table th.profile-type {
+  text-align: left;
+  width: 30%; 
+}
+
+.profile-inner-table td.name {
+  text-align: left;
+  font-weight: bold;
+}
+
+.profile-inner-table td.single-data {
+  text-align: left;
+  font-weight: normal;
+}
+
+.profile-name {
+  font-weight: bold;
+}
+
+.profile-name:has(+.data)::after {
+  content: ": ";
+}
+
+.global-rules-section {
+  margin-top: 20px;
+  border-top: 2px solid #000000;
+  padding-top: 15px;
+}
+
+.rules-summary-title {
+  font-size: 14px;
+  font-weight: bold;
+  text-transform: uppercase;
+  margin-bottom: 12px;
+}
+
+.global-rule-item {
+  margin-bottom: 10px;
+  text-align: justify;
+  font-size: 11px;
+}
+
+.rule-name {
+  font-weight: bold;
+  text-transform: uppercase;
+}
+
+ol, ul, menu {
+  margin: 0;
+  padding-left: 16px;
+  margin-bottom: -18px;
+}
+</style>

--- a/classic_fantasy_roster.html
+++ b/classic_fantasy_roster.html
@@ -195,6 +195,7 @@ html, body { margin: 0; padding: 0; background-color: #ffffff; color: #000000; f
 @media print { .no-print { display: none !important; } }
 .master-print-table { width: 100%; border-collapse: collapse; border: none; }
 .master-print-table td { padding: 0; border: none; }
+.master-print-table tr { break-inside: avoid;}
 tfoot { display: table-footer-group; }
 .footer-stamp { text-align: center; border-top: 1px solid #000000; padding-top: 5px; margin-top: 20px; color: #000000; font-size: 9px; text-transform: uppercase; }
 .category-block { display: none; }

--- a/classic_fantasy_roster.html
+++ b/classic_fantasy_roster.html
@@ -26,181 +26,212 @@
             </label>
           </div>
 
-          <forces>
+          <div class="force-title-banner">
+            BATTLE FORCE: 
+            <if field="customName">{{customName}} ({{catalogueName}})</if>
+            <if field="customName" type="not">{{catalogueName}}</if>
+          </div>
+
+          <div class="roster-page force-container">
             
-            <div class="force-title-banner">
-              BATTLE FORCE: 
-              <if field="customName">{{customName}} ({{catalogueName}})</if>
-              <if field="customName" type="not">{{catalogueName}}</if>
+            <div class="document-header">
+              <div class="header-row">
+                <div class="header-field"><span class="label">PLAYER:</span><span class="line"></span></div>
+                <div class="header-field"><span class="label">ARMY NAME:</span><span class="line force-name-text"><if field="customName">{{customName}}</if><if field="customName" type="not">{{name}}</if></span></div>
+              </div>
+              <div class="header-row">
+                
+                <div class="header-field"><span class="label">GENERAL:</span><span class="line force-name-text">
+                  <groupBy>
+                    <units>
+                      <by><if field="primary">{{primary}}</if></by>
+                    </units>
+                    <groups>
+                      <items>
+                        <set name="isGen" value="false"/>
+                        <entries recursive="true">
+                          <if field="name" type="match" value="General" flags="i"><set name="isGen" value="true"/></if>
+                          <if field="categories">
+                            <categories><if field="name" type="match" value="General" flags="i"><set name="isGen" value="true"/></if></categories>
+                          </if>
+                        </entries>
+                        <if field="isGen" type="equals" value="true">
+                          <if field="customName">{{customName}} (</if>{{name}}<if field="customName">)</if>
+                        </if>
+                      </items>
+                    </groups>
+                  </groupBy>
+                </span></div>
+                
+                <div class="header-field"><span class="label">TOTAL PTS:</span><span class="line force-name-text">
+                  <costs><if field="name" type="match" value="pts" flags="i">{{value}}</if></costs>
+                </span></div>
+                
+              </div>
             </div>
 
-            <div class="roster-page force-container">
-              
-              <div class="document-header">
-                <div class="header-row">
-                  <div class="header-field"><span class="label">PLAYER:</span><span class="line"></span></div>
-                  <div class="header-field"><span class="label">ARMY NAME:</span><span class="line force-name-text"><if field="customName">{{customName}}</if><if field="customName" type="not">{{name}}</if></span></div>
-                </div>
-                <div class="header-row">
-                  
-                  <div class="header-field"><span class="label">GENERAL:</span><span class="line force-name-text">
-                    <units>
-                      <set name="isGen" value="false"/>
-                      <entries recursive="true">
-                        <if field="name" type="match" value="General" flags="i"><set name="isGen" value="true"/></if>
-                        <categories><if field="name" type="match" value="General" flags="i"><set name="isGen" value="true"/></if></categories>
-                      </entries>
-                      <if field="isGen" type="equals" value="true">
-                        <if field="customName">{{customName}} (</if>{{name}}<if field="customName">)</if>
-                      </if>
-                    </units>
-                  </span></div>
-                  
-                  <div class="header-field"><span class="label">TOTAL PTS:</span><span class="line force-name-text">
-                    <costs><if field="name" type="match" value="pts" flags="i">{{value}}</if></costs>
-                  </span></div>
-                  
-                </div>
-              </div>
+            <groupBy>
+              <units>
+                <by>
+                  <if field="primary">{{primary}}</if>
+                  <if field="primary" type="not">General Rules</if>
+                </by>
+              </units>
 
-              <categories skip-empty="true">
-                <if field="name" type="match" value="^(Lord|Lords|Heroes|Core|Special|Rare|Mercenaries|Regiments? of Renown|Characters|Special Characters|Named Characters)$" flags="i">
-                  
+              <groups>
+                <if field="primary" type="not-match" value="^(Special list rules|Experimental rules)$" flags="i">
                   <div class="category-block">
-                    <h3 class="category-title">{{name}}</h3>
+                    <items max="1">
+                      <h3 class="category-title">
+                        <if field="primary">{{primary}}</if>
+                        <if field="primary" type="not">General Rules</if>
+                      </h3>
+                    </items>
                     
-                    <units dedupe="true">
-                      <div class="unit-card">
-                        <table class="unit-table">
-                          
-                          <tr class="unit-header-row">
-                            <th colspan="2" class="unit-header-name">
-                              UNIT: 
-                              <if field="customName">{{customName}} ({{name}})</if>
-                              <if field="customName" type="not">{{name}}</if>
-                            </th>
+                    <items>
+                      <if type="has-profile" recursive="true">
+                        <div class="unit-card">
+                          <table class="unit-table">
                             
-                            <th class="unit-header-size">SIZE: <span class="calc-size"><entries><if field="type" type="equals" value="model">{{number}}{{amount}}</if></entries></span><span class="fallback-size">{{number}}{{amount}}</span></th>
-
-                            <th class="unit-header-pts">PTS: 
-                              <costs><if field="name" type="match" value="pts" flags="i">{{value}}</if></costs>
-                            </th>
-                            
-                            <th class="unit-header-upgrades">UPGRADES / SELECTIONS</th>
-                            <th class="unit-header-rules">RULES</th>
-                          </tr>
-                          
-                          <tr class="unit-data-row">
-                            
-                            <td colspan="4" class="profile-cell">
-                              <profiles grouped="true" amount="false" exclude="{{ruleProfiles}}">
-                                <table class="profile-inner-table">
-                                  <items max="1">
-                                    <tr>
-                                      <th class="profile-type">{{typeName}}</th>
-                                      <characteristics><if field="length" type="not-equals" value="1"><th class="stat-heading">{{name}}</th></if></characteristics>
-                                    </tr>
-                                  </items>
-                                  <items>
-                                    <tr class="stat-row">
-                                      <characteristics>
-                                        <if field="length" type="equals" value="1">
-                                          <td class="name single-data" colspan="15">
-                                            <span class="profile-name">{{item.name}}</span><span class="data" type="markdown">{{value}}</span>
-                                          </td>
-                                        </if>
-                                      </characteristics>
-                                      <else>
-                                        <td class="name">{{item.name}}</td>
-                                        <characteristics><td class="data" type="markdown">{{value}}</td></characteristics>
-                                      </else>
-                                    </tr>
-                                  </items>
-                                </table>
-                              </profiles>
-                            </td>
-                            
-                            <td class="upgrades-cell">
+                            <tr class="unit-header-row">
+                              <th colspan="2" class="unit-header-name">
+                                UNIT: 
+                                <if field="customName">{{customName}} ({{name}})</if>
+                                <if field="customName" type="not">{{name}}</if>
+                              </th>
                               
-                              <costs>
-                                <if field="name" type="not-match" value="pts" flags="i">
-                                  <div class="list-item"><strong>{{name}}:</strong> {{value}}</div>
-                                </if>
-                              </costs>
+                              <th class="unit-header-size">SIZE: <span class="calc-size"><entries><if field="type" type="equals" value="model">{{number}}{{amount}}</if></entries></span><span class="fallback-size">{{number}}{{amount}}</span></th>
 
-                              <set name="parentUnitName" value="{{name}}"/>
-                              <dedupe>
-                                <entries>
-                                  <if field="type" type="equals" value="upgrade">
-                                    <if field="name" type="not-equals" value="{{parentUnitName}}">
-                                      <div class="list-item">
-                                        <if field="number" type="greater" value="1">{{number}}x </if>
-                                        <if field="amount" type="greater" value="1">{{amount}}x </if>
-                                        {{name}}
-                                      </div>
-                                    </if>
-                                  </if>
-                                </entries>
-
-                                <entries>
-                                  <if field="type" type="equals" value="model">
-                                    <entries>
-                                      <if field="type" type="equals" value="upgrade">
-                                        <if field="name" type="not-equals" value="{{parentUnitName}}">
-                                          <div class="list-item">
-                                            <if field="number" type="greater" value="1">{{number}}x </if>
-                                            <if field="amount" type="greater" value="1">{{amount}}x </if>
-                                            {{name}}
-                                          </div>
-                                        </if>
-                                      </if>
-                                    </entries>
-                                  </if>
-                                </entries>
-                              </dedupe>
-                            </td>
+                              <th class="unit-header-pts">PTS: 
+                                <costs><if field="name" type="match" value="pts" flags="i">{{value}}</if></costs>
+                              </th>
+                              
+                              <th class="unit-header-upgrades">UPGRADES / SELECTIONS</th>
+                              <th class="unit-header-rules">RULES</th>
+                            </tr>
                             
-                            <td class="rules-cell">
-                              <dedupe>
-                                <rules>
-                                  <div class="list-item">{{name}}</div>
-                                </rules>
-                                <profiles include="{{ruleProfiles}}">
-                                  <div class="list-item">{{name}}</div>
+                            <tr class="unit-data-row">
+                              
+                              <td colspan="4" class="profile-cell">
+                                <profiles exclude="{{ruleProfiles}}" recursive="true" grouped="true" amount="false">
+                                  <table class="profile-inner-table">
+                                    <items max="1">
+                                      <tr>
+                                        <th class="profile-type">{{typeName}}</th>
+                                        <characteristics><if field="length" type="not-equals" value="1"><th class="stat-heading">{{name}}</th></if></characteristics>
+                                      </tr>
+                                    </items>
+                                    <items>
+                                      <tr class="stat-row">
+                                        <characteristics>
+                                          <if field="length" type="equals" value="1">
+                                            <td class="name single-data" colspan="15">
+                                              <span class="profile-name">{{item.name}}</span><span class="data" type="markdown">{{value}}</span>
+                                            </td>
+                                          </if>
+                                        </characteristics>
+                                        <else>
+                                          <td class="name">{{item.name}}</td>
+                                          <characteristics><td class="data" type="markdown">{{value}}</td></characteristics>
+                                        </else>
+                                      </tr>
+                                    </items>
+                                  </table>
                                 </profiles>
-                              </dedupe>
-                            </td>
-                          </tr>
-                          
-                        </table>
-                      </div>
-                    </units>
-                  </div>
-                  
-                </if>
-              </categories>
+                              </td>
+                              
+                              <td class="upgrades-cell">
+                                <costs>
+                                  <if field="name" type="not-match" value="pts" flags="i">
+                                    <div class="list-item"><strong>{{name}}:</strong> {{value}}</div>
+                                  </if>
+                                </costs>
 
-              <div class="global-rules-section">
-                <h2 class="rules-summary-title">RULES AND ITEMS GLOSSARY</h2>
+                                <set name="parentUnitName" value="{{name}}"/>
+                                <dedupe>
+                                  <entries>
+                                    <if field="type" type="equals" value="upgrade">
+                                      <if field="name" type="not-equals" value="{{parentUnitName}}">
+                                        <div class="list-item">
+                                          <if field="number" type="greater" value="1">{{number}}x </if>
+                                          <if field="amount" type="greater" value="1">{{amount}}x </if>
+                                          {{name}}
+                                        </div>
+                                      </if>
+                                    </if>
+                                  </entries>
+
+                                  <entries>
+                                    <if field="type" type="equals" value="model">
+                                      <entries>
+                                        <if field="type" type="equals" value="upgrade">
+                                          <if field="name" type="not-equals" value="{{parentUnitName}}">
+                                            <div class="list-item">
+                                              <if field="number" type="greater" value="1">{{number}}x </if>
+                                              <if field="amount" type="greater" value="1">{{amount}}x </if>
+                                              {{name}}
+                                            </div>
+                                          </if>
+                                        </if>
+                                      </entries>
+                                    </if>
+                                  </entries>
+                                </dedupe>
+                              </td>
+                              
+                              <td class="rules-cell">
+                                <dedupe>
+                                  <rules>
+                                    <div class="list-item">{{name}}</div>
+                                  </rules>
+                                  <profiles include="{{ruleProfiles}}">
+                                    <div class="list-item">{{name}}</div>
+                                  </profiles>
+                                </dedupe>
+                              </td>
+                            </tr>
+                            
+                          </table>
+                        </div>
+                      </if>
+                    </items>
+                  </div>
+                </if>
+              </groups>
+            </groupBy>
+
+            <div class="global-rules-section">
+              <h2 class="rules-summary-title">RULES AND ITEMS GLOSSARY</h2>
+              
+              <dedupe>
+                <entries recursive="true">
+                  <rules>
+                    <div class="global-rule-item">
+                      <span class="rule-name">{{name}}:</span>
+                      <span class="rule-desc" type="markdown">{{description}}</span>
+                    </div>
+                  </rules>
+
+                  <profiles include="{{ruleProfiles}}">
+                    <div class="global-rule-item">
+                      <span class="rule-name">{{name}}:</span>
+                      <characteristics>
+                        <span class="rule-desc" type="markdown">{{value}}</span>
+                      </characteristics>
+                    </div>
+                  </profiles>
+                </entries>
                 
-                <rules sort="true">
+                <rules>
                   <div class="global-rule-item">
                     <span class="rule-name">{{name}}:</span>
                     <span class="rule-desc" type="markdown">{{description}}</span>
                   </div>
                 </rules>
+              </dedupe>
+            </div>
 
-                <profiles include="{{ruleProfiles}}" sort="true">
-                  <div class="global-rule-item">
-                    <span class="rule-name">{{name}}:</span>
-                    <characteristics>
-                      <span class="rule-desc" type="markdown">{{value}}</span>
-                    </characteristics>
-                  </div>
-                </profiles>
-              </div>
-
-            </div> </forces>
+          </div> 
 
         </div> </td>
     </tr>

--- a/classic_fantasy_roster.html
+++ b/classic_fantasy_roster.html
@@ -227,8 +227,8 @@ tfoot { display: table-footer-group; }
 .upgrades-cell, .rules-cell { padding: 6px; font-size: 9px; }
 .list-item { margin-bottom: 3px; padding-left: 8px; text-indent: -8px; }
 .list-item::before { content: "- "; }
-.profile-inner-table { border-collapse: collapse; width: 100%; border: none; table-layout: fixed; }
-.profile-inner-table th, .profile-inner-table td { border: 1px solid #000000; padding: 3px 5px; text-align: center; word-wrap: break-word; }
+.profile-inner-table { border-collapse: collapse; width: 100%; border: none; table-layout: auto; }
+.profile-inner-table th, .profile-inner-table td { border: 1px solid #000000; padding: 3px 5px; text-align: center; word-wrap: normal; }
 .profile-inner-table th { font-weight: bold; text-transform: uppercase; font-size: 9px; background-color: #e6e6e6 !important; border-top: 1px solid #000000; }
 .profile-inner-table th.profile-type { text-align: left; width: 30%; }
 .profile-inner-table td.name { text-align: left; font-weight: bold; }

--- a/classic_fantasy_roster.html
+++ b/classic_fantasy_roster.html
@@ -1,524 +1,239 @@
-<template>      
-<set name="ruleProfiles" value="special rule,rule,rules,command"/>
+<template>
+  <div id="template-root">
+    <set name="ruleProfiles" value="special rule,rule,rules,command"/>
 
-<table class="master-print-table">
-  
-  <tfoot>
-    <tr>
-      <td>
-        <div class="footer-stamp">COPYRIGHT GAMES WORKSHOP LTD 2000. PERMISSION IS GRANTED TO PHOTOCOPY THIS PAGE FOR PERSONAL USE ONLY.</div>
-      </td>
-    </tr>
-  </tfoot>
-
-  <tbody>
-    <tr>
-      <td>
-
-        <div class="roster-state-wrapper">
+    <script>
+      globalCatName = "";
+      globalArmyName = "";
+      
+      try {
+        if(typeof roster !== 'undefined') {
+          // Attempt to grab the Roster custom name, fallback to file name
+          if(roster.customName) {
+             globalArmyName = roster.customName;
+          } else if(roster.name) {
+             globalArmyName = roster.name;
+          }
           
-          <div class="scribe-controls no-print">
-            <input type="checkbox" id="hide-rules-toggle" />
-            <label for="hide-rules-toggle">
-              <strong>HIDE RULES GLOSSARY</strong> 
-              <br/>
-              <span class="control-subtext">(Check this box to instantly remove the Rules &amp; Profiles Glossary from the bottom of your Battle Forces before printing).</span>
-            </label>
-          </div>
+          // The proven path from our Scanner Test to get 'Dogs of War'
+          if(roster.selector) {
+            if(roster.selector.root) {
+              if(roster.selector.root.book) {
+                 globalCatName = roster.selector.root.book.name; 
+              }
+            }
+          }
+        }
+      } catch(e) {}
+    </script>
 
-          <div class="force-title-banner">
-            BATTLE FORCE: 
-            <if field="customName">{{customName}} ({{catalogueName}})</if>
-            <if field="customName" type="not">{{catalogueName}}</if>
-          </div>
+    <table class="master-print-table">
+      <tfoot>
+        <tr>
+          <td>
+            <div class="footer-stamp">COPYRIGHT GAMES WORKSHOP LTD 2000. PERMISSION IS GRANTED TO PHOTOCOPY THIS PAGE FOR PERSONAL USE ONLY.</div>
+          </td>
+        </tr>
+      </tfoot>
 
-          <div class="roster-page force-container">
-            
-            <div class="document-header">
-              <div class="header-row">
-                <div class="header-field"><span class="label">PLAYER:</span><span class="line"></span></div>
-                <div class="header-field"><span class="label">ARMY NAME:</span><span class="line force-name-text"><if field="customName">{{customName}}</if><if field="customName" type="not">{{name}}</if></span></div>
+      <tbody>
+        <tr>
+          <td>
+            <div class="roster-state-wrapper">
+              <div class="scribe-controls no-print">
+                <input type="checkbox" id="hide-rules-toggle" />
+                <label for="hide-rules-toggle">
+                  <strong>HIDE RULES GLOSSARY</strong> 
+                  <br/>
+                  <span class="control-subtext">(Check this box to instantly remove the Rules &amp; Profiles Glossary from the bottom of your Battle Forces before printing).</span>
+                </label>
               </div>
-              <div class="header-row">
-                
-                <div class="header-field"><span class="label">GENERAL:</span><span class="line force-name-text">
-                  <groupBy>
-                    <units>
-                      <by><if field="primary">{{primary}}</if></by>
-                    </units>
-                    <groups>
-                      <items>
-                        <set name="isGen" value="false"/>
-                        <entries recursive="true">
-                          <if field="name" type="match" value="General" flags="i"><set name="isGen" value="true"/></if>
-                          <if field="categories">
-                            <categories><if field="name" type="match" value="General" flags="i"><set name="isGen" value="true"/></if></categories>
+
+              <div class="force-title-banner">
+                BATTLE FORCE: {{globalArmyName}} 
+                <if field="globalCatName">({{globalCatName}})</if>
+              </div>
+
+              <div class="roster-page force-container">
+                <div class="document-header">
+                  <div class="header-row">
+                    <div class="header-field"><span class="label">PLAYER:</span><span class="line"></span></div>
+                    <div class="header-field">
+                      <span class="label">ARMY NAME:</span>
+                      <span class="line force-name-text">
+                        {{globalArmyName}}
+                      </span>
+                    </div>
+                  </div>
+                  <div class="header-row">
+                    <div class="header-field">
+                      <span class="label">GENERAL:</span>
+                      <span class="line force-name-text">
+                        <groupBy>
+                          <units><by><if field="primary">{{primary}}</if></by></units>
+                          <groups>
+                            <items>
+                              <set name="isGen" value="false"/>
+                              <entries recursive="true">
+                                <if field="name" type="match" value="General" flags="i"><set name="isGen" value="true"/></if>
+                                <if field="categories">
+                                  <categories><if field="name" type="match" value="General" flags="i"><set name="isGen" value="true"/></if></categories>
+                                </if>
+                              </entries>
+                              <if field="isGen" type="equals" value="true">
+                                <if field="customName">{{customName}} (</if>{{name}}<if field="customName">)</if>
+                              </if>
+                            </items>
+                          </groups>
+                        </groupBy>
+                      </span>
+                    </div>
+                    <div class="header-field">
+                      <span class="label">TOTAL PTS:</span>
+                      <span class="line force-name-text">
+                        <costs><if field="name" type="match" value="pts" flags="i">{{value}}</if></costs>
+                      </span>
+                    </div>
+                  </div>
+                  
+                  <if field="note">
+                    <div class="roster-note-block">
+                      <strong>ROSTER NOTES:</strong> <span type="markdown">{{note}}</span>
+                    </div>
+                  </if>
+                </div>
+
+                <groupBy>
+                  <units><by><if field="primary">{{primary}}</if><if field="primary" type="not">General Rules</if></by></units>
+                  <groups>
+                    <if field="primary" type="not-match" value="^(Special list rules|Experimental rules|Campaign/Scenario rules)$" flags="i">
+                      <div class="category-block">
+                        <items max="1">
+                          <h3 class="category-title">
+                            <if field="primary">{{primary}}</if>
+                            <if field="primary" type="not">General Rules</if>
+                          </h3>
+                        </items>
+                        <items>
+                          <if type="has-profile" recursive="true">
+                            <div class="unit-card">
+                              <table class="unit-table">
+                                <tr class="unit-header-row">
+                                  <th colspan="2" class="unit-header-name">UNIT: <if field="customName">{{customName}} ({{name}})</if><if field="customName" type="not">{{name}}</if></th>
+                                  <th class="unit-header-size">SIZE: <span class="calc-size"><entries><if field="type" type="equals" value="model">{{number}}{{amount}}</if></entries></span><span class="fallback-size">{{number}}{{amount}}</span></th>
+                                  <th class="unit-header-pts">PTS: <costs><if field="name" type="match" value="pts" flags="i">{{value}}</if></costs></th>
+                                  <th class="unit-header-upgrades">UPGRADES / SELECTIONS</th>
+                                  <th class="unit-header-rules">RULES</th>
+                                </tr>
+                                <tr class="unit-data-row">
+                                  <td colspan="4" class="profile-cell">
+                                    <profiles exclude="{{ruleProfiles}}" recursive="true" grouped="true" amount="false">
+                                      <table class="profile-inner-table">
+                                        <items max="1">
+                                          <tr><th class="profile-type">{{typeName}}</th><characteristics><if field="length" type="not-equals" value="1"><th class="stat-heading">{{name}}</th></if></characteristics></tr>
+                                        </items>
+                                        <items>
+                                          <tr class="stat-row">
+                                            <characteristics>
+                                              <if field="length" type="equals" value="1"><td class="name single-data" colspan="15"><span class="profile-name">{{item.name}}</span><span class="data" type="markdown">{{value}}</span></td></if>
+                                            </characteristics>
+                                            <else><td class="name">{{item.name}}</td><characteristics><td class="data" type="markdown">{{value}}</td></characteristics></else>
+                                          </tr>
+                                        </items>
+                                      </table>
+                                    </profiles>
+                                  </td>
+                                  <td class="upgrades-cell">
+                                    <costs><if field="name" type="not-match" value="pts" flags="i"><div class="list-item"><strong>{{name}}:</strong> {{value}}</div></if></costs>
+                                    <set name="parentUnitName" value="{{name}}"/>
+                                    <dedupe>
+                                      <entries><if field="type" type="equals" value="upgrade"><if field="name" type="not-equals" value="{{parentUnitName}}"><div class="list-item"><if field="number" type="greater" value="1">{{number}}x </if>{{name}}</div></if></if></entries>
+                                    </dedupe>
+                                  </td>
+                                  <td class="rules-cell">
+                                    <dedupe>
+                                      <rules><div class="list-item">{{name}}</div></rules>
+                                      <profiles include="{{ruleProfiles}}"><div class="list-item">{{name}}</div></profiles>
+                                    </dedupe>
+                                  </td>
+                                </tr>
+                                <if field="note"><tr class="unit-note-row"><td colspan="6" class="unit-note-cell"><strong>NOTE:</strong> <span type="markdown">{{note}}</span></td></tr></if>
+                              </table>
+                            </div>
                           </if>
-                        </entries>
-                        <if field="isGen" type="equals" value="true">
-                          <if field="customName">{{customName}} (</if>{{name}}<if field="customName">)</if>
-                        </if>
-                      </items>
-                    </groups>
-                  </groupBy>
-                </span></div>
-                
-                <div class="header-field"><span class="label">TOTAL PTS:</span><span class="line force-name-text">
-                  <costs><if field="name" type="match" value="pts" flags="i">{{value}}</if></costs>
-                </span></div>
-                
-              </div>
-            </div>
+                        </items>
+                      </div>
+                    </if>
+                  </groups>
+                </groupBy>
 
-            <groupBy>
-              <units>
-                <by>
-                  <if field="primary">{{primary}}</if>
-                  <if field="primary" type="not">General Rules</if>
-                </by>
-              </units>
-
-              <groups>
-                <if field="primary" type="not-match" value="^(Special list rules|Experimental rules)$" flags="i">
-                  <div class="category-block">
-                    <items max="1">
-                      <h3 class="category-title">
-                        <if field="primary">{{primary}}</if>
-                        <if field="primary" type="not">General Rules</if>
-                      </h3>
-                    </items>
-                    
-                    <items>
-                      <if type="has-profile" recursive="true">
-                        <div class="unit-card">
-                          <table class="unit-table">
-                            
-                            <tr class="unit-header-row">
-                              <th colspan="2" class="unit-header-name">
-                                UNIT: 
-                                <if field="customName">{{customName}} ({{name}})</if>
-                                <if field="customName" type="not">{{name}}</if>
-                              </th>
-                              
-                              <th class="unit-header-size">SIZE: <span class="calc-size"><entries><if field="type" type="equals" value="model">{{number}}{{amount}}</if></entries></span><span class="fallback-size">{{number}}{{amount}}</span></th>
-
-                              <th class="unit-header-pts">PTS: 
-                                <costs><if field="name" type="match" value="pts" flags="i">{{value}}</if></costs>
-                              </th>
-                              
-                              <th class="unit-header-upgrades">UPGRADES / SELECTIONS</th>
-                              <th class="unit-header-rules">RULES</th>
-                            </tr>
-                            
-                            <tr class="unit-data-row">
-                              
-                              <td colspan="4" class="profile-cell">
-                                <profiles exclude="{{ruleProfiles}}" recursive="true" grouped="true" amount="false">
-                                  <table class="profile-inner-table">
-                                    <items max="1">
-                                      <tr>
-                                        <th class="profile-type">{{typeName}}</th>
-                                        <characteristics><if field="length" type="not-equals" value="1"><th class="stat-heading">{{name}}</th></if></characteristics>
-                                      </tr>
-                                    </items>
-                                    <items>
-                                      <tr class="stat-row">
-                                        <characteristics>
-                                          <if field="length" type="equals" value="1">
-                                            <td class="name single-data" colspan="15">
-                                              <span class="profile-name">{{item.name}}</span><span class="data" type="markdown">{{value}}</span>
-                                            </td>
-                                          </if>
-                                        </characteristics>
-                                        <else>
-                                          <td class="name">{{item.name}}</td>
-                                          <characteristics><td class="data" type="markdown">{{value}}</td></characteristics>
-                                        </else>
-                                      </tr>
-                                    </items>
-                                  </table>
-                                </profiles>
-                              </td>
-                              
-                              <td class="upgrades-cell">
-                                <costs>
-                                  <if field="name" type="not-match" value="pts" flags="i">
-                                    <div class="list-item"><strong>{{name}}:</strong> {{value}}</div>
-                                  </if>
-                                </costs>
-
-                                <set name="parentUnitName" value="{{name}}"/>
-                                <dedupe>
-                                  <entries>
-                                    <if field="type" type="equals" value="upgrade">
-                                      <if field="name" type="not-equals" value="{{parentUnitName}}">
-                                        <div class="list-item">
-                                          <if field="number" type="greater" value="1">{{number}}x </if>
-                                          <if field="amount" type="greater" value="1">{{amount}}x </if>
-                                          {{name}}
-                                        </div>
-                                      </if>
-                                    </if>
-                                  </entries>
-
-                                  <entries>
-                                    <if field="type" type="equals" value="model">
-                                      <entries>
-                                        <if field="type" type="equals" value="upgrade">
-                                          <if field="name" type="not-equals" value="{{parentUnitName}}">
-                                            <div class="list-item">
-                                              <if field="number" type="greater" value="1">{{number}}x </if>
-                                              <if field="amount" type="greater" value="1">{{amount}}x </if>
-                                              {{name}}
-                                            </div>
-                                          </if>
-                                        </if>
-                                      </entries>
-                                    </if>
-                                  </entries>
-                                </dedupe>
-                              </td>
-                              
-                              <td class="rules-cell">
-                                <dedupe>
-                                  <rules>
-                                    <div class="list-item">{{name}}</div>
-                                  </rules>
-                                  <profiles include="{{ruleProfiles}}">
-                                    <div class="list-item">{{name}}</div>
-                                  </profiles>
-                                </dedupe>
-                              </td>
-                            </tr>
-                            
-                          </table>
-                        </div>
-                      </if>
-                    </items>
-                  </div>
-                </if>
-              </groups>
-            </groupBy>
-
-            <div class="global-rules-section">
-              <h2 class="rules-summary-title">RULES AND ITEMS GLOSSARY</h2>
-              
-              <dedupe>
-                <entries recursive="true">
-                  <rules>
-                    <div class="global-rule-item">
-                      <span class="rule-name">{{name}}:</span>
-                      <span class="rule-desc" type="markdown">{{description}}</span>
-                    </div>
-                  </rules>
-
-                  <profiles include="{{ruleProfiles}}">
-                    <div class="global-rule-item">
-                      <span class="rule-name">{{name}}:</span>
-                      <characteristics>
-                        <span class="rule-desc" type="markdown">{{value}}</span>
-                      </characteristics>
-                    </div>
-                  </profiles>
-                </entries>
-                
-                <rules>
-                  <div class="global-rule-item">
-                    <span class="rule-name">{{name}}:</span>
-                    <span class="rule-desc" type="markdown">{{description}}</span>
-                  </div>
-                </rules>
-              </dedupe>
-            </div>
-
-          </div> 
-
-        </div> </td>
-    </tr>
-  </tbody>
-</table> 
-
+                <div class="global-rules-section">
+                  <h2 class="rules-summary-title">RULES AND ITEMS GLOSSARY</h2>
+                  <dedupe>
+                    <entries recursive="true">
+                      <rules><div class="global-rule-item"><span class="rule-name">{{name}}:</span> <span class="rule-desc" type="markdown">{{description}}</span></div></rules>
+                      <profiles include="{{ruleProfiles}}"><div class="global-rule-item"><span class="rule-name">{{name}}:</span> <characteristics><span class="rule-desc" type="markdown">{{value}}</span></characteristics></div></profiles>
+                    </entries>
+                  </dedupe>
+                </div>
+              </div> 
+            </div> 
+          </td>
+        </tr>
+      </tbody>
+    </table> 
+  </div>
 </template>
 
 <style>
-/* Pure Black and White Printable PDF Clone */
-@page {
-  size: auto;
-  margin: 12mm; 
-}
-
-html, body {
-  margin: 0;
-  padding: 0;
-  background-color: #ffffff; 
-  color: #000000; 
-  font-family: Arial, Helvetica, sans-serif; 
-  font-size: 11px; 
-  line-height: 1.2;
-}
-
-* {
-  box-sizing: border-box;
-  print-color-adjust: exact !important;
-  -webkit-print-color-adjust: exact !important;
-}
-
-/* INTERACTIVE TOGGLE LOGIC */
-.scribe-controls {
-  background-color: #f5f5f5;
-  border: 2px dashed #000000;
-  margin: 20px auto;
-  padding: 15px;
-  max-width: 1000px;
-  text-align: center;
-}
-
-.control-subtext {
-  font-size: 11px;
-  font-style: italic;
-  color: #555;
-}
-
-.roster-state-wrapper:has(#hide-rules-toggle:checked) .global-rules-section {
-  display: none !important;
-}
-
-@media print {
-  .no-print { display: none !important; }
-}
-
-/* MASTER PRINT TABLE */
-.master-print-table {
-  width: 100%;
-  border-collapse: collapse;
-  border: none;
-}
-
-.master-print-table td {
-  padding: 0;
-  border: none;
-}
-
-tfoot {
-  display: table-footer-group; 
-}
-
-.footer-stamp {
-  text-align: center;
-  border-top: 1px solid #000000;
-  padding-top: 5px;
-  margin-top: 20px;
-  color: #000000;
-  font-size: 9px;
-  text-transform: uppercase;
-}
-
-/* EMPTY CATEGORY & SIZE FIXES */
+@page { size: auto; margin: 12mm; }
+html, body { margin: 0; padding: 0; background-color: #ffffff; color: #000000; font-family: Arial, Helvetica, sans-serif; font-size: 11px; line-height: 1.2; }
+* { box-sizing: border-box; print-color-adjust: exact !important; -webkit-print-color-adjust: exact !important; }
+.scribe-controls { background-color: #f5f5f5; border: 2px dashed #000000; margin: 20px auto; padding: 15px; max-width: 1000px; text-align: center; }
+.control-subtext { font-size: 11px; font-style: italic; color: #555; }
+.roster-state-wrapper:has(#hide-rules-toggle:checked) .global-rules-section { display: none !important; }
+@media print { .no-print { display: none !important; } }
+.master-print-table { width: 100%; border-collapse: collapse; border: none; }
+.master-print-table td { padding: 0; border: none; }
+tfoot { display: table-footer-group; }
+.footer-stamp { text-align: center; border-top: 1px solid #000000; padding-top: 5px; margin-top: 20px; color: #000000; font-size: 9px; text-transform: uppercase; }
 .category-block { display: none; }
 .category-block:has(.unit-card) { display: block; }
 .calc-size:not(:empty) + .fallback-size { display: none; }
-
-/* ROSTER LAYOUT */
-.force-title-banner {
-  background-color: #000000;
-  color: #ffffff;
-  text-align: center;
-  font-size: 16px;
-  font-weight: bold;
-  padding: 8px;
-  margin-top: 30px;
-  margin-bottom: 20px;
-  border: 2px solid #000000;
-  text-transform: uppercase;
-  max-width: 1000px;
-  margin-left: auto;
-  margin-right: auto;
-}
-
-.force-container {
-  margin-bottom: 60px;
-  padding-bottom: 40px;
-  border-bottom: 8px solid #000000;
-  page-break-after: always;
-}
-
-.roster-page {
-  width: 100%;
-  max-width: 1000px;
-  margin: 0 auto;
-}
-
-.document-header {
-  margin-top: 20px;
-  margin-bottom: 25px;
-  width: 100%;
-}
-
-.header-row {
-  display: flex;
-  justify-content: space-between;
-  margin-bottom: 8px;
-}
-
-.header-field {
-  display: flex;
-  flex: 1;
-  align-items: flex-end;
-  margin-right: 20px;
-}
-
-.header-field .label {
-  font-weight: bold;
-  font-size: 12px;
-  margin-right: 5px;
-  white-space: nowrap;
-}
-
-.header-field .line {
-  flex-grow: 1;
-  border-bottom: 1px solid #000000;
-  height: 1em;
-  padding-left: 5px;
-  font-style: italic;
-  font-size: 13px;
-}
-
-.category-title {
-  font-size: 14px;
-  font-weight: bold;
-  text-transform: uppercase;
-  background-color: #000000;
-  color: #ffffff;
-  padding: 4px 8px;
-  margin-bottom: 12px;
-  border: 1px solid #000000;
-  page-break-after: avoid;
-}
-
-.unit-card {
-  break-inside: avoid;
-  page-break-inside: avoid;
-  margin-bottom: 24px;
-  width: 100%;
-}
-
-.unit-table {
-  border-collapse: collapse;
-  width: 100%;
-  table-layout: fixed; 
-  border: 2px solid #000000; 
-  background-color: #ffffff;
-}
-
-.unit-header-row th {
-  background-color: #ffffff;
-  color: #000000;
-  font-size: 11px;
-  font-weight: bold;
-  text-transform: uppercase;
-  border: 1px solid #000000;
-  padding: 6px 8px;
-  text-align: left;
-}
-
+.force-title-banner { background-color: #000000; color: #ffffff; text-align: center; font-size: 16px; font-weight: bold; padding: 8px; margin-top: 30px; margin-bottom: 20px; border: 2px solid #000000; text-transform: uppercase; max-width: 1000px; margin-left: auto; margin-right: auto; }
+.force-container { margin-bottom: 60px; padding-bottom: 40px; border-bottom: 8px solid #000000; page-break-after: always; }
+.roster-page { width: 100%; max-width: 1000px; margin: 0 auto; }
+.document-header { margin-top: 20px; margin-bottom: 25px; width: 100%; }
+.header-row { display: flex; justify-content: space-between; margin-bottom: 8px; }
+.header-field { display: flex; flex: 1; align-items: flex-end; margin-right: 20px; }
+.header-field .label { font-weight: bold; font-size: 12px; margin-right: 5px; white-space: nowrap; }
+.header-field .line { flex-grow: 1; border-bottom: 1px solid #000000; height: 1em; padding-left: 5px; font-style: italic; font-size: 13px; }
+.roster-note-block { margin-top: 15px; padding: 8px 10px; border: 1px solid #000000; background-color: #fcfcfc; font-size: 11px; }
+.category-title { font-size: 14px; font-weight: bold; text-transform: uppercase; background-color: #000000; color: #ffffff; padding: 4px 8px; margin-bottom: 12px; border: 1px solid #000000; page-break-after: avoid; }
+.unit-card { break-inside: avoid; page-break-inside: avoid; margin-bottom: 24px; width: 100%; }
+.unit-table { border-collapse: collapse; width: 100%; table-layout: fixed; border: 2px solid #000000; background-color: #ffffff; }
+.unit-header-row th { background-color: #ffffff; color: #000000; font-size: 11px; font-weight: bold; text-transform: uppercase; border: 1px solid #000000; padding: 6px 8px; text-align: left; }
 .unit-header-name { width: 35%; }
 .unit-header-size { width: 10%; text-align: center; }
 .unit-header-pts { width: 10%; text-align: center; }
 .unit-header-upgrades { width: 22.5%; }
 .unit-header-rules { width: 22.5%; }
-
-.unit-data-row td {
-  vertical-align: top;
-  border: 1px solid #000000;
-  padding: 0; 
-}
-
-.upgrades-cell, .rules-cell {
-  padding: 6px; 
-  font-size: 10px;
-}
-
-.list-item {
-  margin-bottom: 3px;
-  padding-left: 8px;
-  text-indent: -8px;
-}
-
-.list-item::before {
-  content: "- ";
-}
-
-.profile-inner-table {
-  border-collapse: collapse;
-  width: 100%;
-  border: none; 
-}
-
-.profile-inner-table th, .profile-inner-table td {
-  border: 1px solid #000000;
-  padding: 3px 5px; 
-  text-align: center;
-  word-wrap: break-word; 
-}
-
-.profile-inner-table th {
-  font-weight: bold;
-  text-transform: uppercase;
-  font-size: 10px;
-  background-color: #e6e6e6 !important; 
-  border-top: 1px solid #000000; 
-}
-
-.profile-inner-table th.profile-type {
-  text-align: left;
-  width: 30%; 
-}
-
-.profile-inner-table td.name {
-  text-align: left;
-  font-weight: bold;
-}
-
-.profile-inner-table td.single-data {
-  text-align: left;
-  font-weight: normal;
-}
-
-.profile-name {
-  font-weight: bold;
-}
-
-.profile-name:has(+.data)::after {
-  content: ": ";
-}
-
-.global-rules-section {
-  margin-top: 20px;
-  border-top: 2px solid #000000;
-  padding-top: 15px;
-}
-
-.rules-summary-title {
-  font-size: 14px;
-  font-weight: bold;
-  text-transform: uppercase;
-  margin-bottom: 12px;
-}
-
-.global-rule-item {
-  margin-bottom: 10px;
-  text-align: justify;
-  font-size: 11px;
-}
-
-.rule-name {
-  font-weight: bold;
-  text-transform: uppercase;
-}
-
-ol, ul, menu {
-  margin: 0;
-  padding-left: 16px;
-  margin-bottom: -18px;
-}
+.unit-data-row td { vertical-align: top; border: 1px solid #000000; padding: 0; }
+.unit-note-cell { border: 1px solid #000000; padding: 6px 8px; font-size: 11px; background-color: #fafafa; border-top: 1px dashed #000000; }
+.upgrades-cell, .rules-cell { padding: 6px; font-size: 10px; }
+.list-item { margin-bottom: 3px; padding-left: 8px; text-indent: -8px; }
+.list-item::before { content: "- "; }
+.profile-inner-table { border-collapse: collapse; width: 100%; border: none; }
+.profile-inner-table th, .profile-inner-table td { border: 1px solid #000000; padding: 3px 5px; text-align: center; word-wrap: break-word; }
+.profile-inner-table th { font-weight: bold; text-transform: uppercase; font-size: 10px; background-color: #e6e6e6 !important; border-top: 1px solid #000000; }
+.profile-inner-table th.profile-type { text-align: left; width: 30%; }
+.profile-inner-table td.name { text-align: left; font-weight: bold; }
+.profile-inner-table td.single-data { text-align: left; font-weight: normal; }
+.profile-name { font-weight: bold; }
+.profile-name:has(+.data)::after { content: ": "; }
+.global-rules-section { margin-top: 20px; border-top: 2px solid #000000; padding-top: 15px; }
+.rules-summary-title { font-size: 14px; font-weight: bold; text-transform: uppercase; margin-bottom: 12px; }
+.global-rule-item { margin-bottom: 10px; text-align: justify; font-size: 11px; }
+.rule-name { font-weight: bold; text-transform: uppercase; }
+ol, ul, menu { margin: 0; padding-left: 16px; margin-bottom: -18px; }
 </style>

--- a/classic_fantasy_roster.html
+++ b/classic_fantasy_roster.html
@@ -28,14 +28,6 @@
     </script>
 
     <table class="master-print-table">
-      <tfoot>
-        <tr>
-          <td>
-            <div class="footer-stamp">COPYRIGHT GAMES WORKSHOP LTD 2000. PERMISSION IS GRANTED TO PHOTOCOPY THIS PAGE FOR PERSONAL USE ONLY.</div>
-          </td>
-        </tr>
-      </tfoot>
-
       <tbody>
         <tr>
           <td>
@@ -46,6 +38,13 @@
                   <strong>HIDE RULES GLOSSARY</strong> 
                   <br/>
                   <span class="control-subtext">(Check this box to instantly remove the Rules &amp; Profiles Glossary from the bottom of your Battle Forces before printing).</span>
+                </label>
+                <br/><br/> 
+                <input type="checkbox" id="pagebreak-rules-toggle" />
+                <label for="pagebreak-rules-toggle">
+                  <strong>RULES ON NEW PAGE</strong> 
+                  <br/>
+                  <span class="control-subtext">(Check this box to force the Rules &amp; Profiles Glossary onto its own separate page when printing).</span>
                 </label>
               </div>
 
@@ -191,18 +190,22 @@ html, body { margin: 0; padding: 0; background-color: #ffffff; color: #000000; f
 * { box-sizing: border-box; print-color-adjust: exact !important; -webkit-print-color-adjust: exact !important; }
 .scribe-controls { background-color: #f5f5f5; border: 2px dashed #000000; margin: 20px auto; padding: 15px; max-width: 1000px; text-align: center; }
 .control-subtext { font-size: 11px; font-style: italic; color: #555; }
+
+/* FIX: Added the missing CSS logic for the pagebreak toggle right here */
 .roster-state-wrapper:has(#hide-rules-toggle:checked) .global-rules-section { display: none !important; }
+.roster-state-wrapper:has(#pagebreak-rules-toggle:checked) .global-rules-section { page-break-before: always !important; break-before: page !important; }
+
 @media print { .no-print { display: none !important; } }
 .master-print-table { width: 100%; border-collapse: collapse; border: none; }
 .master-print-table td { padding: 0; border: none; }
-.master-print-table tr { break-inside: avoid;}
+.master-print-table tr { break-inside: auto; }
 tfoot { display: table-footer-group; }
 .footer-stamp { text-align: center; border-top: 1px solid #000000; padding-top: 5px; margin-top: 20px; color: #000000; font-size: 9px; text-transform: uppercase; }
 .category-block { display: none; }
 .category-block:has(.unit-card) { display: block; }
 .calc-size:not(:empty) + .fallback-size { display: none; }
 .force-title-banner { background-color: #000000; color: #ffffff; text-align: center; font-size: 16px; font-weight: bold; padding: 8px; margin-top: 30px; margin-bottom: 20px; border: 2px solid #000000; text-transform: uppercase; max-width: 1000px; margin-left: auto; margin-right: auto; }
-.force-container { margin-bottom: 60px; padding-bottom: 40px; border-bottom: 8px solid #000000; page-break-after: always; }
+.force-container { margin-bottom: 60px; padding-bottom: 40px; border-bottom: none; page-break-after: always;}
 .roster-page { width: 100%; max-width: 1000px; margin: 0 auto; }
 .document-header { margin-top: 20px; margin-bottom: 25px; width: 100%; }
 .header-row { display: flex; justify-content: space-between; margin-bottom: 8px; }
@@ -212,29 +215,29 @@ tfoot { display: table-footer-group; }
 .roster-note-block { margin-top: 15px; padding: 8px 10px; border: 1px solid #000000; background-color: #fcfcfc; font-size: 11px; }
 .category-title { font-size: 14px; font-weight: bold; text-transform: uppercase; background-color: #000000; color: #ffffff; padding: 4px 8px; margin-bottom: 12px; border: 1px solid #000000; page-break-after: avoid; }
 .unit-card { break-inside: avoid; page-break-inside: avoid; margin-bottom: 24px; width: 100%; }
-.unit-table { border-collapse: collapse; width: 100%; table-layout: fixed; border: 2px solid #000000; background-color: #ffffff; }
+.unit-table { border-collapse: collapse; width: 100%; table-layout: auto; border: 2px solid #000000; background-color: #ffffff; }
 .unit-header-row th { background-color: #ffffff; color: #000000; font-size: 11px; font-weight: bold; text-transform: uppercase; border: 1px solid #000000; padding: 6px 8px; text-align: left; }
 .unit-header-name { width: 35%; }
 .unit-header-size { width: 10%; text-align: center; }
 .unit-header-pts { width: 10%; text-align: center; }
-.unit-header-upgrades { width: 22.5%; }
-.unit-header-rules { width: 22.5%; }
+.unit-header-upgrades { width: 7.0%; }
+.unit-header-rules { width: 7.0%; }
 .unit-data-row td { vertical-align: top; border: 1px solid #000000; padding: 0; }
-.unit-note-cell { border: 1px solid #000000; padding: 6px 8px; font-size: 11px; background-color: #fafafa; border-top: 1px dashed #000000; }
-.upgrades-cell, .rules-cell { padding: 6px; font-size: 10px; }
+.unit-note-cell { border: 1px solid #000000; padding: 6px 8px; font-size: 10px; background-color: #fafafa; border-top: 1px dashed #000000; }
+.upgrades-cell, .rules-cell { padding: 6px; font-size: 9px; }
 .list-item { margin-bottom: 3px; padding-left: 8px; text-indent: -8px; }
 .list-item::before { content: "- "; }
-.profile-inner-table { border-collapse: collapse; width: 100%; border: none; }
+.profile-inner-table { border-collapse: collapse; width: 100%; border: none; table-layout: fixed; }
 .profile-inner-table th, .profile-inner-table td { border: 1px solid #000000; padding: 3px 5px; text-align: center; word-wrap: break-word; }
-.profile-inner-table th { font-weight: bold; text-transform: uppercase; font-size: 10px; background-color: #e6e6e6 !important; border-top: 1px solid #000000; }
+.profile-inner-table th { font-weight: bold; text-transform: uppercase; font-size: 9px; background-color: #e6e6e6 !important; border-top: 1px solid #000000; }
 .profile-inner-table th.profile-type { text-align: left; width: 30%; }
 .profile-inner-table td.name { text-align: left; font-weight: bold; }
 .profile-inner-table td.single-data { text-align: left; font-weight: normal; }
 .profile-name { font-weight: bold; }
 .profile-name:has(+.data)::after { content: ": "; }
-.global-rules-section { margin-top: 20px; border-top: 2px solid #000000; padding-top: 15px; }
-.rules-summary-title { font-size: 14px; font-weight: bold; text-transform: uppercase; margin-bottom: 12px; }
-.global-rule-item { margin-bottom: 10px; text-align: justify; font-size: 11px; }
+.global-rules-section { margin-top: 20px; border-top: none; padding-top: 15px; }
+.rules-summary-title { font-size: 13px; font-weight: bold; text-transform: uppercase; margin-bottom: 12px; }
+.global-rule-item { margin-bottom: 10px; text-align: justify; font-size: 10px; }
 .rule-name { font-weight: bold; text-transform: uppercase; }
 ol, ul, menu { margin: 0; padding-left: 16px; margin-bottom: -18px; }
 </style>

--- a/classic_fantasy_roster.html
+++ b/classic_fantasy_roster.html
@@ -6,7 +6,7 @@
   <tfoot>
     <tr>
       <td>
-        <div class="footer-stamp">COPYRIGHT GAMES WORKSHOP LTD 2000. PERMISSION IS GRANTED TO PHOTOCOPY THIS PAGE FOR PERSONAL USE ONLY. TEMPLATE ARCHITECTED BY KARAK NORN</div>
+        <div class="footer-stamp">COPYRIGHT GAMES WORKSHOP LTD 2000. PERMISSION IS GRANTED TO PHOTOCOPY THIS PAGE FOR PERSONAL USE ONLY.</div>
       </td>
     </tr>
   </tfoot>


### PR DESCRIPTION
Hi team,

After observing consistent feedback from my users that the default export formats (while excellent for skirmish games or the 10th ed 40k cards) do not effectively translate to rank-and-flank systems, I decided to develop a dedicated solution.

### The Motivation
The primary goal was to provide a "Classic" feel that prioritizes data density over visual flair. This template is designed for players who need a clear, tactical summary at the table without exhausting their printer ink.

### Core Features
- **Traditional Profile Hierarchy**: Restores the horizontal stat-line structure (M, WS, BS, S, T, W, I, A, Ld) used in legacy fantasy systems. Groups by Categories (_Core_, _Special_, _Rare_...)
- **Ink-Saving Design**: Stripped of background textures and decorative assets to ensure high legibility and low resource usage.
- **Toggleable Rules Appendix**: Fully supports NewRecruit’s "Show Descriptions" feature. When unchecked, the template omits the rules explanation in the appendix/glossary, allowing for a compact, single-sheet roster for veteran players.
- **Cross-System Logic**: I have ensured the CSS is robust enough to handle the denser data structures of The Old World (TOW), including dynamic headers for AP (Armour Piercing) and Troop Type.

### Technical Validation & Repository Context
I have back-tested this template against several data architectures to ensure it renders correctly regardless of the backend complexity:
- **WHFB 6th Edition (Definitive)**: My primary development target; handles expanded unit options and complex multi-profile entries.
- **WHFB 6th Edition (Legacy)**: Fully compatible with the older "Official" 6th Edition repository currently available on NewRecruit.
- **Warhammer: The Old World**: Validated against USR-heavy lists (Warriors of Chaos) to ensure long rule descriptions wrap correctly without breaking the layout.

### Known Limitation
Like most current templates in this repository, I have detected that this layout does not yet handle multi-force/allied rosters perfectly. I view this as a generic platform limitation for now, but I wanted to be transparent that this template is optimized for single-force organization lists in its current state.

I've attached sample PDFs showing the output for these various systems. I hope this helps other fantasy players looking for a more traditional tactical summary.

[test_whfb_6th_legacy_high_elves.pdf](https://github.com/user-attachments/files/26743219/test_whfb_6th_legacy_high_elves.pdf)
[test_whfb_6th_lizardmen.pdf](https://github.com/user-attachments/files/26743221/test_whfb_6th_lizardmen.pdf)
[test_tow_beastmen_brayherds.pdf](https://github.com/user-attachments/files/26743222/test_tow_beastmen_brayherds.pdf)

Do not hesitate to contact me for any inquiry or bug!